### PR TITLE
Use functions for imperative api and pass configs in same arg (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,28 @@
 
 * Add the latest version of roact-spring to your wally.toml (e.g., `RoactSpring = "chriscerie/roact-spring@^0.0"`)
 
+## Why react-spring
+
+### Declarative and imperative
+`react-spring` is the perfect bridge between declarative and imperative animations. It takes the best of both worlds and packs them into one flexible library.
+
+### Fluid, powerful, painless
+`react-spring` is designed to make animations fluid, powerful, and painless to build and maintain. Animation becomes easy and approachable, and everything you do looks and feel natural by default.
+
+### Versatile
+`react-spring` works with most data types and provides extensible configurations that makes it painless to create advanced animations.
+
 ## Getting Started
 
 Getting started with roact-spring is as simple as:
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, {
-    from = {
-        position = UDim2.fromScale(0.3, 0.3),
-        rotation = 0,
+local styles, api = RoactSpring.useSpring(hooks, function()
+    return {
+        from = {
+            position = UDim2.fromScale(0.3, 0.3),
+            rotation = 0,
+        }
     }
 })
 
@@ -39,10 +52,11 @@ return Roact.createElement("TextButton", {
     Size = UDim2.fromScale(0.3, 0.3),
     [Roact.Event.Activated] = function()
         api.start({
-            position = UDim2.fromScale(0.5, 0.5),
-            rotation = 45,
-        }, {
-            tension = 170, friction = 26,
+            to = {
+                position = UDim2.fromScale(0.5, 0.5),
+                rotation = 45,
+            },
+            config = { tension = 170, friction = 26 },
         }):andThen(function()
             print("Animation finished!")
         end)

--- a/docs/Common/configs.md
+++ b/docs/Common/configs.md
@@ -35,7 +35,6 @@ The following configs are available:
 | friction | 26 | spring resistence |
 | clamp | false | when true, stops the spring once it overshoots its boundaries |
 | precision | 0.005 | how close to the end result the animated value gets before we consider it to be "there" |
-| velocity | 0 | initial velocity |
 | easing | t => t | linear by default, there is a multitude of easings available here |
 | duration | nil | if > than 0, will switch to a duration-based animation instead of spring physics, value should be indicated in seconds (e.g. duration: 2 for a duration of 2s) |
 | bounce | nil | When above zero, the spring will bounce instead of overshooting when exceeding its goal value. |

--- a/docs/Common/imperatives.md
+++ b/docs/Common/imperatives.md
@@ -4,27 +4,50 @@ sidebar_position: 4
 
 # Imperatives
 
-The api table in the second value returned from a spring has the following functions:
+## Imperative API
+
+Passing a function to `useSpring` or `useSprings` will return an imperative API table. The following shows the difference between using the imperative and declarative API for toggling transparency.
 
 ```lua
-local api = {
-    -- Start your animation optionally giving new props to merge 
-    start: (props) => Promise,
-    -- Cancel some or all animations depending on the keys passed, no keys will cancel all.
-    stop: (keys) => void,
-    -- Pause some or all animations depending on the keys passed, no keys will pause all.
-    pause: (keys) => void,
-}
+--[[
+    Using declarative API
+]]
+local toggle, setToggle = useState(false)
+local styles = RoactSpring.useSpring(hooks, {
+    from = { transparency = 1 },
+    to = { transparency = if toggle then 0 else 1 },
+})
+
+-- Later
+setToggle(function(prevState)
+    return not prevState
+end)
+
+
+--[[
+    Using imperative API
+]]
+local styles, api = RoactSpring.useSpring(hooks, function()
+    return {
+        from = { transparency = 1 },
+    }
+end)
+
+-- Later
+api.start({ transparency = if styles.transparency:getValue() == 1 then 0 else 1 })
 ```
 
-You can also specify configs for each animation.
+The rest of this page will use the imperative API.
+
+You can also specify configs for each animation update.
 
 ```lua
 api.start({
-    position = UDim2.fromScale(0.5, 0.5),
-    rotation = 0,
-}, {
-    mass = 10, tension = 100, friction = 50,
+    to = {
+        position = UDim2.fromScale(0.5, 0.5),
+        rotation = 0,
+    },
+    config = { mass = 10, tension = 100, friction = 50 },
 })
 ```
 
@@ -38,3 +61,22 @@ api.start({
     print("Animation finished!")
 end)
 ```
+
+## API methods
+
+The api table in the second value returned from a spring has the following functions:
+
+```lua
+local api = {
+    -- Start your animation optionally giving new props to merge 
+    start: (props) => Promise,
+    -- Cancel some or all animations depending on the keys passed, no keys will cancel all.
+    stop: (keys) => void,
+    -- Pause some or all animations depending on the keys passed, no keys will pause all.
+    pause: (keys) => void,
+}
+```
+
+:::note
+roact-spring guarantees that the api table identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency array.
+:::note

--- a/docs/Common/props.md
+++ b/docs/Common/props.md
@@ -4,6 +4,8 @@ sidebar_position: 2
 
 # Props
 
+## Overview
+
 ```lua
 RoactSpring.useSpring(hooks, {
     from = { ... }
@@ -15,4 +17,34 @@ All primitives inherit the following properties (though some of them may bring t
 | Property | Type | Description  |
 | ----------- | ----------- | ---- |
 | from | table | Starting values |
+| to | table | Animates to ... |
+| immediate | boolean | Prevents animation if true. |
 | [Configs](configs) | table | 	Spring config (contains mass, tension, friction, etc) |
+
+## Default props
+
+### Imperative updates
+
+Imperative updates inherit default props declared from passing props to `useSprings` or `useSpring`.
+
+```lua
+local styles, api = RoactSpring.useSpring(hooks, function()
+    return {
+        from = { Position = UDim2.fromScale(0.5, 0.5) },
+        config = { immediate = true },
+    }
+end)
+
+hooks.useEffect(function()
+    -- The `config` prop is inherited by the animation
+    -- Animation will jump immediately to the parent
+    api.start({ Position = UDim2.fromScale(0.3, 0.3) })
+end)
+```
+
+### Compatible props
+
+The following props can have default values:
+
+* `immediate`
+

--- a/docs/Hooks/useSpring.md
+++ b/docs/Hooks/useSpring.md
@@ -10,7 +10,7 @@ Defines values into animated values.
 
 ### Either: declaratively overwrite values to change the animation
 
-If you pass a `to` table, roact-spring will animate to `to` on mount and on every re-render. If you don't want the animation to run on mount, ensure `to` = `from` on the first render.
+If you re-render the component with changed props, the animation will update. If you don't want the animation to run on mount, ensure `to` equals `from` or `nil` on the first render.
 
 ```lua
 local styles = RoactSpring.useSpring(hooks, {
@@ -19,26 +19,20 @@ local styles = RoactSpring.useSpring(hooks, {
 })
 ```
 
-### Or: imperatively update using the api
+### Or: pass a function that returns values, and imperatively update using the api
 
-If you don't pass a `to` table, you will get an api table back. It will not automatically animate on mount and re-render, but you can call `api.start` to start the animation. Handling updates like this is generally preferred as it's more powerful. Further documentation can be found in [Imperatives](/docs/common/imperatives).
+You will get an API table back. It will not automatically animate on mount and re-render, but you can call `api.start` to start the animation. Handling updates like this is generally preferred as it's more powerful. Further documentation can be found in [Imperatives](/docs/common/imperatives).
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, {
-    from = {
-        position = UDim2.fromScale(0.3, 0.3),
-        rotation = 0,
-    },
-    config = { mass = 10, tension = 100, friction = 50 }
+local styles, api = RoactSpring.useSpring(hooks, function()
+    return {
+        from = { transparency = 0 },
+    }
 })
 
 -- Update spring with new props
-api.start({
-    position = UDim2.fromScale(0.5, 0.5),
-    rotation = 0,
-})
-task.wait(1)
--- Stop animation after 1 second
+api.start({ transparency = if toggle 1 else 0 })
+-- Stop animation
 api.stop()
 ```
 
@@ -46,10 +40,25 @@ api.stop()
 
 ```lua
 return Roact.createElement("Frame", {
-    Position = styles.position.value,
-    Rotation = styles.rotation.value,
+    Transparency = styles.transparency,
     Size = UDim2.fromScale(0.3, 0.3),
 })
+```
+
+## Properties
+
+All properties documented in the [common props](/docs/common/props) apply.
+
+## Additional notes
+
+### To-prop shortcut
+If the only props in an update are `to`, then you can just pass the `to` table directly.
+
+```lua
+-- This...
+api.start({ transparency = 1 })
+-- is a shortcut for this...
+api.start({ to = { transparency = 0 } })
 ```
 
 ## Demos

--- a/docs/Hooks/useSprings.md
+++ b/docs/Hooks/useSprings.md
@@ -8,17 +8,43 @@ sidebar_position: 6
 
 Creates multiple springs, each with its own config. Use it for static lists, etc.
 
-Pass in the length as well as a function that returns the props for each spring.
+### Either: declaratively overwrite values to change the animation
+
+If you re-render the component with changed props, the animation will update. If you don't want the animation to run on mount, ensure `to` equals `from` or `nil` on the first render.
 
 ```lua
-local springs, api = RoactSpring.useSprings(hooks, 4, function(index)
-    return {
-        from = { Position = UDim2.fromScale(0.5, index * 0.16) },
-    }
-end)
+local springProps = {}
+local length = #items
+for index, item in ipairs(items) do
+    table.insert(springProps, {
+        from = { transparency = item.transparency },
+        to = { transparency = if toggles[i] then 1 else 0 },
+    })
+end
+local springs = RoactSpring.useSprings(hooks, length, springProps)
 ```
 
-Apply styles to components.
+### Or: pass a function that returns values, and imperatively update using the api
+
+You will get an API table back. It will not automatically animate on mount and re-render, but you can call `api.start` to start the animation. Handling updates like this is generally preferred as it's more powerful. Further documentation can be found in [Imperatives](/docs/common/imperatives).
+
+```lua
+local length = #items
+local springs, api = RoactSpring.useSprings(hooks, length, function(index)
+    return {
+        from = { transparency = items[index].transparency },
+    }
+end)
+
+-- Start animations
+api.start(function(index)
+    return { Position = UDim2.fromScale(0.5 * index, 0.16) }
+end)
+-- Stop all springs
+api.stop()
+```
+
+### Finally: apply styles to components
 
 ```lua
 local contents = {}
@@ -29,14 +55,6 @@ for i = 1, 4 do
     })
 end
 return contents
-```
-
-Start animations.
-
-```lua
-api.start(function(index)
-    return { Position = UDim2.fromScale(0.5 * index, 0.16) }
-end)
 ```
 
 ## Properties

--- a/src/AnimationConfig.lua
+++ b/src/AnimationConfig.lua
@@ -1,10 +1,10 @@
 local constants = require(script.Parent.constants)
-local merge = require(script.Parent.util.merge)
+local util = require(script.Parent.util)
 
 local AnimationConfig = {}
 
-local defaults = table.freeze(merge(constants.config.default, {
-    immediate = false,
+local defaults = table.freeze(util.merge(constants.config.default, {
+    --immediate = false,
     mass = 1,
     clamp = false,
     precision = 0.005,
@@ -12,8 +12,83 @@ local defaults = table.freeze(merge(constants.config.default, {
     easing = constants.easings.linear,
 }))
 
-function AnimationConfig:applyDefaults(config)
-    return merge(defaults, config)
+export type SpringConfigs = {
+    --[[
+        Higher mass means more friction is required to slow down.
+        Defaults to 1, which works fine most of the time.
+    ]]
+    mass: number?,
+
+    --[[
+        With higher tension, the spring will resist bouncing and try harder to stop at its end value.
+        When tension is zero, no animation occurs.
+    ]]
+    tension: number?,
+
+    --[[
+        The damping ratio coefficient.
+        Higher friction means the spring will slow down faster.
+    ]]
+    friction: number?,
+
+    --[[
+        Avoid overshooting by ending abruptly at the goal value.
+    ]]
+    clamp: boolean?,
+
+    --[[
+        The smallest distance from a value before that distance is essentially zero.
+
+        This helps in deciding when a spring is "at rest". The spring must be within
+        this distance from its final value, and its velocity must be lower than this
+        value too (unless `restVelocity` is defined).
+    ]]
+    precision: number?,
+
+    --[[
+        The initial velocity of one or more values.
+    ]]
+    velocity: number?,
+
+    --[[
+        The animation curve. Only used when `duration` is defined.
+        TODO: Define default easing
+    ]]
+    easing: (t: number) -> number?,
+
+    --[[
+        Animation length in number of seconds.
+    ]]
+    duration: number?,
+
+    --[[
+        When above zero, the spring will bounce instead of overshooting when
+        exceeding its goal value. Its velocity is multiplied by `-1 + bounce`
+        whenever its current value equals or exceeds its goal. For example,
+        setting `bounce` to `0.5` chops the velocity in half on each bounce,
+        in addition to any friction.
+    ]]
+    bounce: number?,
+
+    --[[
+        The smallest velocity before the animation is considered "not moving".
+        When undefined, `precision` is used instead.
+    ]]
+    restVelocity: number?,
+}
+
+function AnimationConfig:mergeConfig(config: any, newConfig: any?): SpringConfigs
+    if newConfig then
+        config = util.merge(config, newConfig)
+    end
+
+    for k, v in pairs(defaults) do
+        if config[k] == nil then
+            config[k] = v
+        end
+    end
+
+    return config
 end
 
 return AnimationConfig

--- a/src/useSpring.lua
+++ b/src/useSpring.lua
@@ -10,8 +10,9 @@ local SpringValue = require(script.Parent.SpringValue)
 local Spring = require(script.Parent.Spring)
 local merge = require(script.Parent.util.merge)
 
-type UseSpringProps = {
-    [string]: any,
+type UseSpringProps = Spring.SpringProps | () -> {
+    from: { [string]: any },
+    config: { [string]: any }?
 }
 
 --[=[
@@ -29,10 +30,20 @@ type UseSpringProps = {
     @return ({[string]: RoactBinding}, api)
 ]=]
 local function useSpring(hooks, props: UseSpringProps)
-    assert(typeof(props) == "table", "Props for `useSpring` is required.")
-
+    local isImperative = hooks.useValue(nil)
     local spring = hooks.useValue(nil)
-    local isMounted = hooks.useValue(false)
+
+    if typeof(props) == "table" then
+        assert(isImperative.value == nil or isImperative.value == false, "useSpring detected a change from imperative to declarative. This is not supported.")
+        isImperative.value = false
+    elseif typeof(props) == "function" then
+        assert(isImperative.value == nil or isImperative.value == true, "useSpring detected a change from declarative to imperative. This is not supported.")
+        isImperative.value = true
+        props = props()
+    else
+        error("Expected table or function for useSpring, got " .. typeof(props))
+    end
+    assert(props.from, "From prop is required for useSpring")
 
     if spring.value == nil then
         local binding, api = Spring.new(props)
@@ -43,18 +54,20 @@ local function useSpring(hooks, props: UseSpringProps)
     end
 
     hooks.useEffect(function()
-        spring.value.api.setProps(props)
-        
-        if typeof(props.to) == "table" then
-            spring.value.api.start(props.to)
+        if isImperative.value == false then
+            spring.value.api.setProps(props)
+
+            if typeof(props.to) == "table" then
+                spring.value.api.start(props.to)
+            end
         end
     end)
 
-    if props.to then
-        return spring.value.binding
+    if isImperative.value then
+        return spring.value.binding, spring.value.api
     end
 
-    return spring.value.binding, spring.value.api
+    return spring.value.binding
 end
 
 return useSpring

--- a/src/util/init.lua
+++ b/src/util/init.lua
@@ -1,0 +1,6 @@
+local util = {
+    copy = require(script.copy),
+    merge = require(script.merge),
+}
+
+return util

--- a/src/util/map.lua
+++ b/src/util/map.lua
@@ -1,0 +1,12 @@
+local function map(dictionary, mapper)
+	local new = {}
+
+	for key, value in pairs(dictionary) do
+		local newValue, newKey = mapper(value, key)
+		new[newKey or key] = newValue
+	end
+
+	return new
+end
+
+return map

--- a/stories/Spring.story.lua
+++ b/stories/Spring.story.lua
@@ -24,10 +24,7 @@ function Example:render()
         [Roact.Event.Activated] = function()
             self.api.start({
                 position = UDim2.fromScale(0.5, 0.8),
-            }, {
-            }):andThen(function()
-                print("Completed")
-            end)
+            })
         end,
 	}, {
         UICorner = e("UICorner"),

--- a/stories/SpringDrag.story.lua
+++ b/stories/SpringDrag.story.lua
@@ -40,9 +40,12 @@ function Example:render()
                         local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
 
                         self.api.start({
-                            position = UDim2.fromOffset(mousePos.X, mousePos.Y),
-                            size = UDim2.fromOffset(180, 180),
-                        }, { tension = 100, friction = 10 })
+                            to = {
+                                position = UDim2.fromOffset(mousePos.X, mousePos.Y),
+                                size = UDim2.fromOffset(180, 180)
+                            },
+                            config = { tension = 100, friction = 10 },
+                        })
                     end)
                 end
             end
@@ -51,8 +54,9 @@ function Example:render()
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 if self.connection then
                     self.api.start({
-                        size = UDim2.fromOffset(150, 150),
-                    }, ({ tension = 100, friction = 10 }))
+                        to = { size = UDim2.fromOffset(150, 150) },
+                        config = { tension = 100, friction = 10 },
+                    })
                     self.connection:Disconnect()
                     self.connection = nil
                 end

--- a/stories/useSpringBouncePause.story.lua
+++ b/stories/useSpringBouncePause.story.lua
@@ -12,11 +12,13 @@ local e = Roact.createElement
 local PAUSE_AFTER_SECONDS = 1.5
 
 local function Button(props, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, {
-        from = {
-            position = UDim2.fromScale(0.5, 0.5),
-        },
-    })
+    local styles, api = RoactSpring.useSpring(hooks, function()
+        return {
+            from = {
+                position = UDim2.fromScale(0.5, 0.5),
+            },
+        }
+    end)
 
 	return e("TextButton", {
         AnchorPoint = Vector2.new(0.5, 0.5),
@@ -28,9 +30,8 @@ local function Button(props, hooks)
 
         [Roact.Event.Activated] = function()
             api.start({
-                position = UDim2.fromScale(0.5, 0.8),
-            }, {
-                bounce = 1, tension = 180, friction = 0,
+                to = { position = UDim2.fromScale(0.5, 0.8) },
+                config = { bounce = 1, tension = 180, friction = 0 },
             })
             task.wait(PAUSE_AFTER_SECONDS)
             api.pause()

--- a/stories/useSpringBounceStop.story.lua
+++ b/stories/useSpringBounceStop.story.lua
@@ -12,11 +12,13 @@ local e = Roact.createElement
 local STOP_AFTER_SECONDS = 3
 
 local function Button(props, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, {
-        from = {
-            position = UDim2.fromScale(0.5, 0.3),
-        },
-    })
+    local styles, api = RoactSpring.useSpring(hooks, function()
+        return {
+            from = {
+                position = UDim2.fromScale(0.5, 0.3),
+            },
+        }
+    end)
 
 	return e("TextButton", {
         AnchorPoint = Vector2.new(0.5, 0.5),
@@ -28,9 +30,8 @@ local function Button(props, hooks)
 
         [Roact.Event.Activated] = function()
             api.start({
-                position = UDim2.fromScale(0.5, 0.8),
-            }, {
-                mass = 2.5, bounce = 1, tension = 180, friction = 0,
+                to = { position = UDim2.fromScale(0.5, 0.8) },
+                config = { mass = 2.5, bounce = 1, tension = 180, friction = 0 },
             })
             task.wait(STOP_AFTER_SECONDS)
             api.stop()

--- a/stories/useSpringDeclarative.story.lua
+++ b/stories/useSpringDeclarative.story.lua
@@ -7,8 +7,10 @@ local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local e = Roact.createElement
 
 local function Button(props, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, {
+    local toggle, setToggle = hooks.useState(false)
+    local styles = RoactSpring.useSpring(hooks, {
         from = { position = UDim2.fromScale(0.5, 0.5) },
+        to = { position = if toggle then UDim2.fromScale(0.5, 0.8) else UDim2.fromScale(0.5, 0.5) }
     })
 
 	return e("TextButton", {
@@ -19,11 +21,8 @@ local function Button(props, hooks)
         Text = "Click me",
 
         [Roact.Event.Activated] = function()
-            api.start({
-                position = UDim2.fromScale(0.5, 0.8),
-            }, {
-            }):andThen(function()
-                print("Completed")
+            setToggle(function(prevState)
+                return not prevState
             end)
         end,
 	}, {

--- a/stories/useSpringDrag.story.lua
+++ b/stories/useSpringDrag.story.lua
@@ -15,12 +15,14 @@ local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local e = Roact.createElement
 
 local function Button(props, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, {
-        from = {
-            size = UDim2.fromOffset(150, 150),
-            position = UDim2.fromScale(0.5, 0.5),
-        },
-    })
+    local styles, api = RoactSpring.useSpring(hooks, function()
+        return {
+            from = {
+                size = UDim2.fromOffset(150, 150),
+                position = UDim2.fromScale(0.5, 0.5),
+            },
+        }
+    end)
     local connection = hooks.useValue()
 
 	return e("TextButton", {

--- a/stories/useSpringEasingClick.story.lua
+++ b/stories/useSpringEasingClick.story.lua
@@ -15,12 +15,14 @@ local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local e = Roact.createElement
 
 local function Button(props, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, {
-        from = {
-            size = UDim2.fromOffset(150, 150),
-            position = UDim2.fromScale(0.5, 0.5),
-        },
-    })
+    local styles, api = RoactSpring.useSpring(hooks, function()
+        return {
+            from = {
+                size = UDim2.fromOffset(150, 150),
+                position = UDim2.fromScale(0.5, 0.5),
+            },
+        }
+    end)
     local connection = hooks.useValue()
 
     hooks.useEffect(function()
@@ -28,8 +30,9 @@ local function Button(props, hooks)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
                 api.start({
-                    position = UDim2.fromOffset(mousePos.X, mousePos.Y),
-                }, ({ duration = 3, easing = RoactSpring.easings.easeInElastic }))
+                    to = { position = UDim2.fromOffset(mousePos.X, mousePos.Y) },
+                    config = { duration = 3, easing = RoactSpring.easings.easeInElastic },
+                })
             end
         end)
 

--- a/stories/useSpringImperative.story.lua
+++ b/stories/useSpringImperative.story.lua
@@ -9,25 +9,20 @@ local e = Roact.createElement
 local function Button(props, hooks)
     local styles, api = RoactSpring.useSpring(hooks, function()
         return {
-            from = {
-                Rotation = 0,
-                Position = UDim2.fromScale(0.5, 0.5),
-            },
+            from = { position = UDim2.fromScale(0.5, 0.5) },
         }
     end)
 
 	return e("TextButton", {
         AnchorPoint = Vector2.new(0.5, 0.5),
-        Position = styles.Position,
-		Size = UDim2.fromScale(0.3, 0.3),
+        Position = styles.position,
+		Size = UDim2.fromOffset(30, 30),
 		BackgroundColor3 = Color3.fromRGB(99, 255, 130),
-        Rotation = styles.Rotation,
         Text = "Click me",
 
         [Roact.Event.Activated] = function()
             api.start({
-                to = { Position = UDim2.fromScale(0.5, 0.8) },
-                immediate = true,
+                position = UDim2.fromScale(0.5, 0.8),
             })
         end,
 	}, {

--- a/stories/useSpringsEasing.story.lua
+++ b/stories/useSpringsEasing.story.lua
@@ -18,13 +18,16 @@ end
 
 local function Button(props, hooks)
     local atTarget, setAtTarget = hooks.useState(false)
-    local springs = RoactSpring.useSprings(hooks, #easingsArray, function(i)
-        return {
+
+    local springProps = {}
+    for i in ipairs(easingsArray) do
+        table.insert(springProps, {
             from = { Position = UDim2.fromScale(0.2, 0.05 + i * 0.03) },
             to = { Position = UDim2.fromScale(if atTarget then 0.2 else 0.8, 0.05 + i * 0.03) },
             config = { easing = easingsArray[i].easing, duration = 2 },
-        }
-    end)
+        })
+    end
+    local springs = RoactSpring.useSprings(hooks, #easingsArray, springProps)
 
     hooks.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)

--- a/stories/useSpringsList.story.lua
+++ b/stories/useSpringsList.story.lua
@@ -75,13 +75,19 @@ local function Button(props, hooks)
                         api.start(function(i)
                             if i == index then
                                 return {
-                                    Position = UDim2.fromScale(0.5, (yPos - frame.AbsolutePosition.Y) / frame.AbsoluteSize.Y),
-                                    ZIndex = 10,
-                                }, { immediate = true, }
+                                    to = {
+                                        Position = UDim2.fromScale(0.5, (yPos - frame.AbsolutePosition.Y) / frame.AbsoluteSize.Y),
+                                        ZIndex = 10,
+                                    },
+                                    immediate = true,
+                                }
                             end
                             return {
-                                ZIndex = 1,
-                            }, { immediate = true, }
+                                to = {
+                                    ZIndex = 1,
+                                },
+                                immediate = true,
+                            }
                         end)
 
                         api.start(function(i)

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chriscerie/roact-spring"
 description = "A spring-physics based animation library for Roact inspired by react-spring"
-version = "0.0.13"
+version = "0.0.15"
 license = "MIT"
 authors = ["chriscerie"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
### Breaking: pass in a table for declarative API and function for imperative API
```lua
-- Declarative
local styles = RoactSpring.useSpring(hooks, {
    from = { transparency = 0 },
    to = { transparency = if toggle then 1 else 0 },
})

-- Imperative
local styles, api = RoactSpring.useSpring(hooks, function()
    return {
        from = { transparency = 0 },
    }
})
```
Previously, the imperative and declarative APIs are set by whether you passed in a `to` table. This deviated from react-spring, and the reasoning was that lua's lack of arrow functions makes passing in a function more verbose than the js counterpart. After some more thought, I decided against this for a couple of reasons:

* It's more difficult to distinguish between using the declarative and imperative APIs. Hardcoding a check for a key to vary its usage drastically just feels wrong and is closely aligned with passing in flags to vary its behavior, which I am a strong believer that it is an anti pattern.
* It wouldn't be possible to use the declarative API without passing in a `to` table. If you didn't want the animation to animate on mount, your only option would've been to either pass in the same value as `from` or passing in a flag (e.g., false). Not passing in a `to` table at all is easier to reason about its behavior in practice.

### Breaking: pass in configs in the same argument

```lua
-- Before
api.start(
    { position = UDim2.fromScale(0.5, 0.5) },
    { tension = 170, friction = 26 },
)

-- Now
api.start({
    to = { position = UDim2.fromScale(0.5, 0.5) },
    config = { tension = 170, friction = 26 },
})
```

Previously, you would pass the config prop in the second argument of `api.start`. The reasoning was also syntactical as config is a major common prop makes sense to have its own arg, but I eventually decided against this as well.