### PR TITLE
Add duration progress for easing animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fixed `useTrail` delaying the wrong amount for varying delay times
 * Fixed typo in docs
+* Added `progress` config for easing animations ([@chriscerie](https://github.com/chriscerie) in [#13](https://github.com/chriscerie/roact-spring/pull/13))
 
 ## 0.2.0 (Feburary 11, 2022)
 

--- a/docs/Common/configs.md
+++ b/docs/Common/configs.md
@@ -41,6 +41,7 @@ The following configs are available:
 | velocity | 0 | initial velocity, see [velocity config](/docs/common/configs#velocity-config) for more detais |
 | easing | t => t | linear by default, there is a multitude of easings available [here](/docs/common/configs#easings) |
 | damping | 1 | The damping ratio, which dictates how the spring slows down. Only works when `frequency` is defined. Defaults to `1`. |
+| progress | 0 | When used with `duration`, it decides how far into the easing function to start from. The duration itself is unaffected. |
 | duration | undefined | if > than 0, will switch to a duration-based animation instead of spring physics, value should be indicated in seconds (e.g. duration: 2 for a duration of 2s) |
 | frequency | undefined | The frequency response (in seconds), which dictates the duration of one period in a frictionless environment. When defined, `tension` is derived from this, and `friction` is derived from this and `damping`. |
 | bounce | undefined | When above zero, the spring will bounce instead of overshooting when exceeding its goal value. |

--- a/src/AnimationConfig.lua
+++ b/src/AnimationConfig.lua
@@ -46,6 +46,20 @@ export type SpringConfigs = {
     precision: number?,
 
     --[[
+        For `duration` animations only. Note: The `duration` is not affected
+        by this property.
+        
+        Defaults to `0`, which means "start from the beginning".
+        
+        Setting to `1+` makes an immediate animation.
+        
+        Setting to `0.5` means "start from the middle of the easing function".
+    
+        Any number `>= 0` and `<= 1` makes sense here.
+    ]]
+    progress: number?,
+
+    --[[
         The initial velocity of one or more values.
     ]]
     velocity: number | { number }?,

--- a/src/Controller.lua
+++ b/src/Controller.lua
@@ -38,7 +38,6 @@ local function prepareKeys(props: ControllerProps)
 end
 
 function Controller.new(props: ControllerProps)
-    -- TODO: Merge all unrecognized props into `to`
     assert(Roact, "Roact not found. It must be placed in the same folder as roact-spring.")
     assert(typeof(props) == "table", "Props are required.")
 

--- a/stories/hooks/useSpringBouncePause.story.lua
+++ b/stories/hooks/useSpringBouncePause.story.lua
@@ -1,7 +1,4 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local RunService = game:GetService("RunService")
-local UserInputService = game:GetService("UserInputService")
-local GuiService = game:GetService("GuiService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
 local Hooks = require(ReplicatedStorage.Packages.Hooks)


### PR DESCRIPTION
Officially adds `progress` to configs. This was technically already implemented, just not documented.

Closes #12 