### PR TITLE
fix: use properly `from` on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Fixed documentation incorrectly using dot operator for controllers
+* Fixed `from` prop during imperative updates ([@lopi-py](https://github.com/lopi-py) in [#22](https://github.com/chriscerie/roact-spring/pull/22))
 
 ## 1.0.0 (April 21, 2022)
 * Bumped promise version to v4.0 ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/20))

--- a/src/SpringValue.lua
+++ b/src/SpringValue.lua
@@ -93,7 +93,7 @@ function SpringValue:_update(props)
 
         if reset then
             anim.values = table.clone(anim.fromValues)
-            anim.lastPosition = table.clone(anim.fromValues)
+            anim.lastPosition = helpers.getValuesFromType(from)
         end
 
         anim.toValues = helpers.getValuesFromType(to)


### PR DESCRIPTION
Hey, I noticed that `reset`(automatically added if `from` is not nil) is not working properly given this
```lua
local styles, motor = RoactSpring.useSpring(hooks, function()
    return { scale = 1 }
end)
```
```lua
motor.start({
    from = { scale = 0 },
    to = { scale = 1 },
})
```