### PR TITLE
[TS] Change Controller start to be a callback

### DIFF
--- a/src/Controller.d.ts
+++ b/src/Controller.d.ts
@@ -6,7 +6,7 @@ export type ControllerProps = AnimationProps & {
 };
 
 export interface ControllerApi {
-  start(startProps?: ControllerProps): Promise<void>;
+  start: (startProps?: ControllerProps) => Promise<void>;
   stop(keys?: [string]): Promise<void>;
   pause(keys?: [string]): Promise<void>;
 }


### PR DESCRIPTION
https://roblox-ts.com/docs/guides/callbacks-vs-methods

`start` is typed as a method so

`api.start({
    transparency: 1
})`

transpiles to

`
api:start({
    transparency = 1,
})
`
(which doesn't work as `api` is passed as first param).

This PR types it as a callback so we get

`api.start({
    transparency = 1
})`

