### PR TITLE
Fix discrepancy with useTrail's api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Fixed `error` when passing reset = true without using from prop ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))
 * Fixed `error` when passing from prop without including all keys ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))
+* Fixed `useTrail` not returning promises on api.start ([@rwilliaise](https://github.com/rwilliaise) in [#33](https://github.com/chriscerie/roact-spring/pull/33))
 
 ## 1.0.1 (May 26, 2022)
 * Fixed documentation incorrectly using dot operator for controllers

--- a/src/hooks/useTrail.lua
+++ b/src/hooks/useTrail.lua
@@ -38,7 +38,7 @@ local function useTrail(hooks, length: number, propsArg, deps: {any}?)
 
         modifiedApi.value.start = function(startFn)
             local currentDelay = 0
-            api.start(function(i)
+            return api.start(function(i)
                 local startProps = util.merge({ delay = 0.1 }, startFn(i))
                 local delayAmount = startProps.delay
                 startProps.delay = currentDelay


### PR DESCRIPTION
There is a small bug with `api.start`, where using it with useTrails does not return a promise.