### PR TITLE
Add support for Roact17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Fixed `error` when passing reset = true without using from prop ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))
 * Fixed `error` when passing from prop without including all keys ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))
 * Fixed `useTrail` not returning promises on api.start ([@rwilliaise](https://github.com/rwilliaise) in [#33](https://github.com/chriscerie/roact-spring/pull/33))
-* Added support for Roact17 ([@chriscerie](https://github.com/chriscerie) in [#35](https://github.com/chriscerie/roact-spring/pull/20))
+* Added support for Roact17 ([@chriscerie](https://github.com/chriscerie) in [#35](https://github.com/chriscerie/roact-spring/pull/35))
 
 ## 1.0.1 (May 26, 2022)
 * Fixed documentation incorrectly using dot operator for controllers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed `error` when passing reset = true without using from prop ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))
 * Fixed `error` when passing from prop without including all keys ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))
 * Fixed `useTrail` not returning promises on api.start ([@rwilliaise](https://github.com/rwilliaise) in [#33](https://github.com/chriscerie/roact-spring/pull/33))
+* Added support for Roact17 ([@chriscerie](https://github.com/chriscerie) in [#35](https://github.com/chriscerie/roact-spring/pull/20))
 
 ## 1.0.1 (May 26, 2022)
 * Fixed documentation incorrectly using dot operator for controllers

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Getting started with roact-spring is as simple as:
 
 ### Declarative
 ```lua
-local toggle, setToggle = Roact.useState(false)
+local toggle, setToggle = React.useState(false)
 local styles = RoactSpring.useSpring({
     transparency = if toggle then 1 else 0,
 })

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Getting started with roact-spring is as simple as:
 ### Declarative
 ```lua
 local toggle, setToggle = hooks.useState(false)
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     transparency = if toggle then 1 else 0,
 })
 
@@ -64,7 +64,7 @@ end)
 ### Imperative
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, function()
+local styles, api = RoactSpring.useSpring(function()
     return {
         position = UDim2.fromScale(0.3, 0.3),
         rotation = 0,

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Getting started with roact-spring is as simple as:
 
 ### Declarative
 ```lua
-local toggle, setToggle = hooks.useState(false)
+local toggle, setToggle = Roact.useState(false)
 local styles = RoactSpring.useSpring({
     transparency = if toggle then 1 else 0,
 })

--- a/docs/Additional Classes/controller.md
+++ b/docs/Additional Classes/controller.md
@@ -23,7 +23,7 @@ function Example:render()
         Position = self.styles.position,
 		Size = self.styles.size,
 
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             self.api:start({
                 size = UDim2.fromOffset(150, 150),
                 config = { tension = 100, friction = 10 },

--- a/docs/Additional Notes.md
+++ b/docs/Additional Notes.md
@@ -23,7 +23,7 @@ local function Example(_)
         }
     end)
 
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         -- We need to call `api.start` for each value
         api.start({ position1 = UDim2.fromScale(0.8, 0.2) })
         api.start({ position2 = UDim2.fromScale(0.2, 0.6) })
@@ -53,7 +53,7 @@ local function Example(_)
         }
     end)
 
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         -- We only have to call `api.start` once
         api.start({ alpha = 1 })
     end, {})

--- a/docs/Additional Notes.md
+++ b/docs/Additional Notes.md
@@ -23,21 +23,21 @@ local function Example(_)
         }
     end)
 
-    Roact.useEffect(function()
+    React.useEffect(function()
         -- We need to call `api.start` for each value
         api.start({ position1 = UDim2.fromScale(0.8, 0.2) })
         api.start({ position2 = UDim2.fromScale(0.2, 0.6) })
         api.start({ position3 = UDim2.fromScale(0.5, 0.9) })
     end, {})
 
-	return Roact.createFragment({
-        Frame1 = Roact.createElement("Frame", {
+	return React.createFragment({
+        Frame1 = React.createElement("Frame", {
             Position = styles.position1,
         }),
-        Frame2 = Roact.createElement("Frame", {
+        Frame2 = React.createElement("Frame", {
             Position = styles.position2,
         }),
-        Frame3 = Roact.createElement("Frame", {
+        Frame3 = React.createElement("Frame", {
             Position = styles.position3,
         }),
     })
@@ -53,23 +53,23 @@ local function Example(_)
         }
     end)
 
-    Roact.useEffect(function()
+    React.useEffect(function()
         -- We only have to call `api.start` once
         api.start({ alpha = 1 })
     end, {})
 
-	return Roact.createFragment({
-        Frame1 = Roact.createElement("Frame", {
+	return React.createFragment({
+        Frame1 = React.createElement("Frame", {
             Position = styles.position:map(function(alpha)
                 return UDim2.fromScale(0.2, 0.2):Lerp(UDim2.fromScale(0.8, 0.2), alpha)
             end),
         }),
-        Frame2 = Roact.createElement("Frame", {
+        Frame2 = React.createElement("Frame", {
             Position = styles.position:map(function(alpha)
                 return UDim2.fromScale(0.1, 0.8):Lerp(UDim2.fromScale(0.2, 0.6), alpha)
             end),
         }),
-        Frame3 = Roact.createElement("Frame", {
+        Frame3 = React.createElement("Frame", {
             Position = styles.position:map(function(alpha)
                 return UDim2.fromScale(0.6, 0.4):Lerp(UDim2.fromScale(0.5, 0.9), alpha)
             end),

--- a/docs/Additional Notes.md
+++ b/docs/Additional Notes.md
@@ -14,8 +14,8 @@ One downside to this approach is that it's only convenient when elements are ani
 
 ### Using different springs for each element
 ```lua
-local function Example(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Example(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             position1 = UDim2.fromScale(0.2, 0.2),
             position2 = UDim2.fromScale(0.1, 0.8),
@@ -46,8 +46,8 @@ end
 
 ### Using alpha values
 ```lua
-local function Example(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Example(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             alpha = 0,
         }

--- a/docs/Common/configs.md
+++ b/docs/Common/configs.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 Springs are configurable and can be tuned. If you want to adjust these settings, you can provide a default `config` table to `useSpring`:
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, function()
+local styles, api = RoactSpring.useSpring(function()
     return {
         from = {
             position = UDim2.fromScale(0.5, 0.5),
@@ -118,7 +118,7 @@ When a number, the `velocity` config applies initial velocity towards or away fr
 
 ```lua
 -- Start with initial velocity away from `to`
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     position = if toggle then UDim2.fromScale(0.5, 0.8) else UDim2.fromScale(0.5, 0.5),
     config = { velocity = -0.01 },
 })
@@ -128,7 +128,7 @@ For further customization on the direction of the velocity, you can pass a table
 
 ```lua
 -- Start with initial velocity pointed towards the top-left corner
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     position = if toggle then UDim2.fromScale(0.5, 0.8) else UDim2.fromScale(0.5, 0.5),
     config = { velocity = {-0.01, 0, -0.01, 0} },
 })
@@ -138,13 +138,13 @@ Passing in a single number where `to` equals `from` will not move the spring at 
 
 ```lua
 -- Will not do anything
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     position = UDim2.fromScale(0.5, 0.5),
     config = { velocity = -0.01 },
 })
 
 -- Will apply velocity towards the top-left corner and then return back to original position
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     position = UDim2.fromScale(0.5, 0.5),
     config = { velocity = {-0.01, 0, -0.01, 0} },
 })

--- a/docs/Common/imperatives.md
+++ b/docs/Common/imperatives.md
@@ -13,7 +13,7 @@ Passing a function to `useSpring` or `useSprings` will return an imperative API 
     Using declarative API
 ]]
 local toggle, setToggle = useState(false)
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     transparency = if toggle then 0 else 1,
 })
 
@@ -26,7 +26,7 @@ end)
 --[[
     Using imperative API
 ]]
-local styles, api = RoactSpring.useSpring(hooks, function()
+local styles, api = RoactSpring.useSpring(function()
     return { transparency = 1 }
 end)
 

--- a/docs/Common/props.md
+++ b/docs/Common/props.md
@@ -46,7 +46,7 @@ Pass a function to be called after each loop. Return `true` to continue looping,
 
 ```lua
 -- Transparency animates from 0 to 1 three times
-local count = Roact.useRef(0)
+local count = React.useRef(0)
 local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     to = { transparency = 1 },
@@ -63,7 +63,7 @@ Define a `loop` table to customize the loop animation separately from the initia
 
 ```lua
 -- Transparency repeatedly animates from 0 to 1 with 1 second delays
-local count = Roact.useRef(0)
+local count = React.useRef(0)
 local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     to = { transparency = 1 },
@@ -170,7 +170,7 @@ local styles, api = RoactSpring.useSpring(function()
     }
 end)
 
-Roact.useEffect(function()
+React.useEffect(function()
     -- The `config` prop is inherited by the animation
     -- Spring will animate with tension at 100
     api.start({ position = UDim2.fromScale(0.3, 0.3) })

--- a/docs/Common/props.md
+++ b/docs/Common/props.md
@@ -170,7 +170,7 @@ local styles, api = RoactSpring.useSpring(function()
     }
 end)
 
-hooks.useEffect(function()
+Roact.useEffect(function()
     -- The `config` prop is inherited by the animation
     -- Spring will animate with tension at 100
     api.start({ position = UDim2.fromScale(0.3, 0.3) })

--- a/docs/Common/props.md
+++ b/docs/Common/props.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 ## Overview
 
 ```lua
-RoactSpring.useSpring(hooks, {
+RoactSpring.useSpring({
     from = { ... }
 })
 ```
@@ -33,7 +33,7 @@ Use `loop = true` to repeat an animation.
 
 ```lua
 -- Transparency repeatedly animates from 0 to 1
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     to = { transparency = 1 },
     loop = true,
@@ -46,8 +46,8 @@ Pass a function to be called after each loop. Return `true` to continue looping,
 
 ```lua
 -- Transparency animates from 0 to 1 three times
-local count = hooks.useValue(0)
-local styles = RoactSpring.useSpring(hooks, {
+local count = Roact.useRef(0)
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     to = { transparency = 1 },
     loop = function()
@@ -63,8 +63,8 @@ Define a `loop` table to customize the loop animation separately from the initia
 
 ```lua
 -- Transparency repeatedly animates from 0 to 1 with 1 second delays
-local count = hooks.useValue(0)
-local styles = RoactSpring.useSpring(hooks, {
+local count = Roact.useRef(0)
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     to = { transparency = 1 },
     loop = { delay = 1, reset = true },
@@ -77,7 +77,7 @@ The `loop` object is always merged into a copy of the props object it was define
 
 ```lua
 -- The loop doesn't run more than once
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     loop = { transparency = 1 },
 })
@@ -91,7 +91,7 @@ Lastly, try adding `config = { friction: 5 }` to the loop object. This overrides
 
 ```lua
 -- Transparency repeatedly animates from 0 to 1
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     loop = {
         transparency = 1,
@@ -100,7 +100,7 @@ local styles = RoactSpring.useSpring(hooks, {
 })
 
 -- Transparency repeatedly animates from 0 to 1
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     loop = {
         transparency = 1,
@@ -114,7 +114,7 @@ local styles = RoactSpring.useSpring(hooks, {
 Use the `reset` prop to start the animation from scratch. When undefined in imperative updates, the spring will assume `reset` is true if `from` is passed. 
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, function()
+local styles, api = RoactSpring.useSpring(function()
     return { transparency = 0.5 }
 end)
 
@@ -136,13 +136,13 @@ In declarative updates, the spring will assume reset is false if reset is not pa
 
 ```lua
 -- The spring will start from 0.2 on mount and ignore `from` on future updates
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     from = { transparency = 0.2 },
     to = { transparency = if toggle then 0 else 1 },
 }, { toggle })
 
 -- The spring will always start from scratch from 0.2
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     reset = true,
     from = { transparency = 0.2 },
     to = { transparency = if toggle then 0 else 1 },
@@ -162,7 +162,7 @@ For the declarative API, this prop is `true` by default.
 Imperative updates can use `default: true` to set default props.
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, function()
+local styles, api = RoactSpring.useSpring(function()
     return {
         position = UDim2.fromScale(0.5, 0.5),
         config = { tension = 100 },

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -13,8 +13,8 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 -- When button is pressed, animate transparency to 0
-local function App(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function App(_)
+    local styles, api = RoactSpring.useSpring(function()
         return { transparency = 1 }
     end)
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ## Getting started with function components and hooks
 
-Getting started with roact-spring is easy. For function components with [hooks](https://github.com/Kampfkarren/roact-hooks), the basic spring is [useSpring](/docs/hooks/useSpring), but the same concept applies to all animation primitives. Let's have a look...
+Getting started with roact-spring is easy. For function components with hooks, the basic spring is [useSpring](/docs/hooks/useSpring), but the same concept applies to all animation primitives. Let's have a look...
 
 ```lua
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -27,6 +27,28 @@ local function App(_)
     })
 end
 ```
+
+`roact-spring` supports both [Roact17](https://github.com/grilme99/CorePackages) and the original [Roact](https://github.com/Roblox/roact) with [roact-hooks](https://github.com/Kampfkarren/roact-hooks). Usage with the original Roact and roact-hooks requires you to pass the `hooks` table to roact-spring's hooks.
+
+#### Using Roact17:
+```lua
+local function App(_)
+    local styles, api = RoactSpring.useSpring(function()
+        return { transparency = 1 }
+    end)
+end
+```
+
+#### Using the original Roact with roact-hooks:
+```lua
+local function App(_, hooks)
+    local styles, api = RoactSpring.useSpring(hooks, function()
+        return { transparency = 1 }
+    end)
+end
+```
+
+The rest of this documentation's examples will assume we are using Roact17.
 
 ## Getting started with class components
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -29,7 +29,7 @@ local function App(_)
 end
 ```
 
-`roact-spring` supports both [Roact17](https://github.com/grilme99/CorePackages) and legacy [Roact](https://github.com/Roblox/roact) with [roact-hooks](https://github.com/Kampfkarren/roact-hooks). Usage with legacy Roact and roact-hooks requires you to pass the `hooks` table to roact-spring's hooks.
+`roact-spring` supports both [Roact17](https://github.com/grilme99/CorePackages) and [legacy Roact](https://github.com/Roblox/roact) with [roact-hooks](https://github.com/Kampfkarren/roact-hooks). Usage with legacy Roact and roact-hooks requires you to pass the `hooks` table to roact-spring's hooks.
 
 #### Using Roact17:
 ```lua

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -10,6 +10,7 @@ Getting started with roact-spring is easy. For function components with hooks, t
 
 ```lua
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local React = require(ReplicatedStorage.Packages.React)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 -- When button is pressed, animate transparency to 0
@@ -18,17 +19,17 @@ local function App(_)
         return { transparency = 1 }
     end)
 
-    return Roact.createElement("TextButton", {
+    return React.CreateElement("TextButton", {
         Size = UDim2.fromScale(0.5, 0.5),
         Transparency = styles.transparency,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({ transparency = 0 })
         end,
     })
 end
 ```
 
-`roact-spring` supports both [Roact17](https://github.com/grilme99/CorePackages) and the original [Roact](https://github.com/Roblox/roact) with [roact-hooks](https://github.com/Kampfkarren/roact-hooks). Usage with the original Roact and roact-hooks requires you to pass the `hooks` table to roact-spring's hooks.
+`roact-spring` supports both [Roact17](https://github.com/grilme99/CorePackages) and legacy [Roact](https://github.com/Roblox/roact) with [roact-hooks](https://github.com/Kampfkarren/roact-hooks). Usage with legacy Roact and roact-hooks requires you to pass the `hooks` table to roact-spring's hooks.
 
 #### Using Roact17:
 ```lua
@@ -39,7 +40,7 @@ local function App(_)
 end
 ```
 
-#### Using the original Roact with roact-hooks:
+#### Using legacy Roact with roact-hooks:
 ```lua
 local function App(_, hooks)
     local styles, api = RoactSpring.useSpring(hooks, function()
@@ -60,6 +61,7 @@ Function components with hooks are always preferred over class components. For m
 
 ```lua
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local React = require(ReplicatedStorage.Packages.React)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 function App:init()
@@ -70,10 +72,10 @@ end
 
 -- When button is pressed, animate transparency to 0
 function App:render()
-    return Roact.createElement("TextButton", {
+    return React.CreateElement("TextButton", {
         Size = UDim2.fromScale(0.5, 0.5),
         Transparency = self.styles.transparency,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             self.api:start({ transparency = 0 })
         end,
     })

--- a/docs/Hooks/useSpring.md
+++ b/docs/Hooks/useSpring.md
@@ -13,7 +13,7 @@ Defines values into animated values.
 If you re-render the component, the animation will update.
 
 ```lua
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     transparency = if toggle then 1 else 0,
 })
 ```
@@ -21,7 +21,7 @@ local styles = RoactSpring.useSpring(hooks, {
 If you want the animation to run on mount, you can use `from` to set the initial value.
 
 ```lua
-local styles = RoactSpring.useSpring(hooks, {
+local styles = RoactSpring.useSpring({
     from = { transparency = 0 },
     to = { transparency = if toggle then 1 else 0 },
 })
@@ -32,7 +32,7 @@ local styles = RoactSpring.useSpring(hooks, {
 You will get an API table back. It will not automatically animate on mount and re-render, but you can call `api.start` to start the animation. Handling updates like this is generally preferred as it's more powerful. Further documentation can be found in [Imperatives](/docs/common/imperatives).
 
 ```lua
-local styles, api = RoactSpring.useSpring(hooks, function()
+local styles, api = RoactSpring.useSpring(function()
     return { transparency = 0 }
 })
 
@@ -72,8 +72,8 @@ local styles = RoactSpring.useSpring({ to = { transparency = 1 } })
 The `styles` table is just a table of bindings. This means you can map them to props as you could for any other bindings if you wanted to achieve custom behavior. Animating with [alpha values](/docs/Additional%20Notes#thinking-in-alpha-values) is a common use case for this.
 
 ```lua
-local function Example(_, hooks)
-    local styles = RoactSpring.useSpring(hooks, {
+local function Example(_)
+    local styles = RoactSpring.useSpring({
         alpha = 0,
     })
 

--- a/docs/Hooks/useSpring.md
+++ b/docs/Hooks/useSpring.md
@@ -45,7 +45,7 @@ api.stop()
 ### Finally: apply styles to components
 
 ```lua
-return Roact.createElement("Frame", {
+return React.createElement("Frame", {
     Transparency = styles.transparency,
     Size = UDim2.fromScale(0.3, 0.3),
 })
@@ -77,11 +77,11 @@ local function Example(_)
         alpha = 0,
     })
 
-    Roact.useEffect(function()
+    React.useEffect(function()
         api.start({ alpha = 1 })
     end, {})
 
-	return Roact.createElement("Frame", {
+	return React.createElement("Frame", {
         Transparency = styes.alpha,
         Position = styles.alpha:map(function(alpha)
             return UDim2.fromScale(0.2, 0.2):Lerp(UDim2.fromScale(0.8, 0.2), alpha)

--- a/docs/Hooks/useSpring.md
+++ b/docs/Hooks/useSpring.md
@@ -77,7 +77,7 @@ local function Example(_)
         alpha = 0,
     })
 
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         api.start({ alpha = 1 })
     end, {})
 

--- a/docs/Hooks/useSprings.md
+++ b/docs/Hooks/useSprings.md
@@ -20,7 +20,7 @@ for index, item in ipairs(items) do
         transparency = if toggles[i] then 1 else 0,
     })
 end
-local springs = RoactSpring.useSprings(hooks, length, springProps)
+local springs = RoactSpring.useSprings(length, springProps)
 ```
 
 If you want the animation to run on mount, you can use `from` to set the initial value.
@@ -34,7 +34,7 @@ for index, item in ipairs(items) do
         to = { transparency = if toggles[i] then 1 else 0 },
     })
 end
-local springs = RoactSpring.useSprings(hooks, length, springProps)
+local springs = RoactSpring.useSprings(length, springProps)
 ```
 
 ### Or: pass a function that returns values, and imperatively update using the api
@@ -43,7 +43,7 @@ You will get an API table back. It will not automatically animate on mount and r
 
 ```lua
 local length = #items
-local springs, api = RoactSpring.useSprings(hooks, length, function(index)
+local springs, api = RoactSpring.useSprings(length, function(index)
     return { transparency = items[index].transparency }
 end)
 

--- a/docs/Hooks/useSprings.md
+++ b/docs/Hooks/useSprings.md
@@ -60,7 +60,7 @@ api.stop()
 ```lua
 local contents = {}
 for i = 1, 4 do
-    contents[i] = Roact.createElement("Frame", {
+    contents[i] = React.createElement("Frame", {
         Position = springs[i].position,
         Size = UDim2.fromScale(0.3, 0.3),
     })

--- a/docs/Hooks/useTrail.md
+++ b/docs/Hooks/useTrail.md
@@ -60,7 +60,7 @@ api.stop()
 ```lua
 local contents = {}
 for i = 1, 4 do
-    contents[i] = Roact.createElement("Frame", {
+    contents[i] = React.createElement("Frame", {
         Position = springs[i].position,
         Size = UDim2.fromScale(0.3, 0.3),
     })

--- a/docs/Hooks/useTrail.md
+++ b/docs/Hooks/useTrail.md
@@ -20,7 +20,7 @@ for index, item in ipairs(items) do
         transparency = if toggles[i] then 1 else 0,
     })
 end
-local springs = RoactSpring.useTrail(hooks, length, springProps)
+local springs = RoactSpring.useTrail(length, springProps)
 ```
 
 If you want the animation to run on mount, you can use `from` to set the initial value.
@@ -34,7 +34,7 @@ for index, item in ipairs(items) do
         to = { transparency = if toggles[i] then 1 else 0 },
     })
 end
-local springs = RoactSpring.useTrail(hooks, length, springProps)
+local springs = RoactSpring.useTrail(length, springProps)
 ```
 
 ### Or: pass a function that returns values, and imperatively update using the api
@@ -43,7 +43,7 @@ You will get an API table back. It will not automatically animate on mount and r
 
 ```lua
 local length = #items
-local springs, api = RoactSpring.useTrail(hooks, length, function(index)
+local springs, api = RoactSpring.useTrail(length, function(index)
     return { transparency = items[index].transparency }
 end)
 
@@ -76,7 +76,7 @@ By default, each spring will start 0.1 seconds after the previous one. You can o
 
 ```lua
 -- Now each spring will start 0.2 seconds after the previous one
-local springs, api = RoactSpring.useTrail(hooks, length, function(index)
+local springs, api = RoactSpring.useTrail(length, function(index)
     return {
         transparency = items[index].transparency,
         delay = 0.2,
@@ -87,7 +87,7 @@ end)
 You can also pass a `delay` property to each spring individually.
 ```lua
 -- The first spring will start 0.1 seconds after the previous one, the second 0.2 seconds, and so on
-local springs, api = RoactSpring.useTrail(hooks, length, function(index)
+local springs, api = RoactSpring.useTrail(length, function(index)
     return {
         transparency = items[index].transparency,
         delay = index * 0.1,

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,7 +12,17 @@ This library represents a modern approach to animation. It is the perfect bridge
 
 ### Wally
 
-Add the latest version of roact-spring to your wally.toml (e.g., `RoactSpring = "chriscerie/roact-spring@^0.0"`)
+`roact-spring` has two packages to support [Roact17](https://github.com/grilme99/CorePackages) and [legacy Roact](https://github.com/Roblox/roact). It is important to install the correct package or you **will** encounter bugs. To install, add the latest version of roact-spring to your wally.toml:
+
+#### With Roact17
+```console
+RoactSpring = "chriscerie/react-spring@<version>"
+```
+
+#### With legacy Roact
+```console
+RoactSpring = "chriscerie/roact-spring@<version>"
+```
 
 ### roblox-ts
 

--- a/react.wally.toml
+++ b/react.wally.toml
@@ -1,0 +1,14 @@
+[package]
+name = "chriscerie/react-spring"
+description = "A modern spring-physics based animation library for Roact inspired by react-spring"
+version = "1.0.1"
+license = "MIT"
+authors = ["chriscerie"]
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[dependencies]
+Promise = "evaera/promise@^4.0"
+TestEZ = "roblox/testez@^0.4"
+React ="core-packages/react@17.0.1-rc.16"
+ReactRoblox = "core-packages/react-roblox@17.0.1-rc.16"

--- a/roact.wally.toml
+++ b/roact.wally.toml
@@ -10,4 +10,4 @@ realm = "shared"
 [dependencies]
 Promise = "evaera/promise@^4.0"
 TestEZ = "roblox/testez@^0.4"
-React ="roblox/roact@1.4.4"
+React ="roblox/roact@^1"

--- a/roact.wally.toml
+++ b/roact.wally.toml
@@ -10,3 +10,4 @@ realm = "shared"
 [dependencies]
 Promise = "evaera/promise@^4.0"
 TestEZ = "roblox/testez@^0.4"
+React ="roblox/roact@1.4.4"

--- a/src/Controller.lua
+++ b/src/Controller.lua
@@ -3,7 +3,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
 local TS = rbxts_include and require(rbxts_include.RuntimeLib)
 
-local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Roact)
+local React = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.React)
 local Promise = if TS then TS.Promise else require(script.Parent.Parent.Promise)
 local SpringValue = require(script.Parent.SpringValue)
 local AnimationConfig = require(script.Parent.AnimationConfig)
@@ -25,7 +25,7 @@ export type ControllerProps = {
 }
 
 function Controller.new(props: ControllerProps)
-    assert(Roact, "Roact not found. It must be placed in the same folder as roact-spring.")
+    assert(React, "React not found. It must be placed in the same folder as roact-spring.")
     assert(typeof(props) == "table", "Props are required.")
 
     local self = setmetatable({
@@ -41,7 +41,7 @@ end
 
 local function createSpring(props, key: string)
     local spring = SpringValue.new(props, key)
-    local binding, setBinding = Roact.createBinding()
+    local binding, setBinding = React.createBinding()
     spring.key = key
     spring.onChange = function(newValue)
         setBinding(newValue)

--- a/src/hooks/useSpring.lua
+++ b/src/hooks/useSpring.lua
@@ -3,11 +3,10 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
 local TS = rbxts_include and require(rbxts_include.RuntimeLib)
 
--- TODO: Since we don't have Roact as a dependency, we need a way to access whichever Roact the user has
-local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
+local React = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.React)
 local useSprings = require(script.Parent.useSprings)
 
-local isRoact17 = not Roact.reconcile
+local isRoact17 = not React.reconcile
 
 if isRoact17 then
     return function(props, deps: {any}?)

--- a/src/hooks/useSpring.lua
+++ b/src/hooks/useSpring.lua
@@ -3,6 +3,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
 local TS = rbxts_include and require(rbxts_include.RuntimeLib)
 
+-- TODO: Since we don't have Roact as a dependency, we need a way to access whichever Roact the user has
 local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
 local useSprings = require(script.Parent.useSprings)
 

--- a/src/hooks/useSpring.lua
+++ b/src/hooks/useSpring.lua
@@ -1,6 +1,28 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
+local TS = rbxts_include and require(rbxts_include.RuntimeLib)
+
+local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
 local useSprings = require(script.Parent.useSprings)
 
-local function useSpring(hooks, props, deps: {any}?)
+local isRoact17 = not Roact.reconcile
+
+if isRoact17 then
+    return function(props, deps: {any}?)
+        local isFn = type(props) == "function"
+
+        local styles, api = useSprings(
+            1,
+            if isFn then props else {props},
+            if isFn then deps or {} else deps
+        )
+
+        return styles[1], api
+    end
+end
+
+return function(hooks, props, deps: {any}?)
     local isFn = type(props) == "function"
 
     local styles, api = useSprings(
@@ -12,5 +34,3 @@ local function useSpring(hooks, props, deps: {any}?)
 
     return styles[1], api
 end
-
-return useSpring

--- a/src/hooks/useSpring.spec.lua
+++ b/src/hooks/useSpring.spec.lua
@@ -1,7 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
@@ -9,20 +8,19 @@ local e = Roact.createElement
 local function createUpdater(initialProps, initialDeps)
     local test = {}
 
-    local function Test(_, hooks)
-        local springProps, update = hooks.useState({ initialProps, initialDeps })
+    local function Test(_)
+        local springProps, update = Roact.useState({ initialProps, initialDeps })
         test.update = function(newProps, newDeps)
             update({ newProps, newDeps })
             task.wait(0.1)
         end
-        test.styles, test.api = RoactSpring.useSpring(hooks, springProps[1], springProps[2])
+        test.styles, test.api = RoactSpring.useSpring(springProps[1], springProps[2])
         return nil
     end
 
-    Test = Hooks.new(Roact)(Test)
-
     test.handle = Roact.mount(e(Test), nil)
 
+    task.wait()
     while not test.handle do
         task.wait()
     end

--- a/src/hooks/useSpring.spec.lua
+++ b/src/hooks/useSpring.spec.lua
@@ -1,15 +1,16 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function createUpdater(initialProps, initialDeps)
     local test = {}
 
     local function Test(_)
-        local springProps, update = Roact.useState({ initialProps, initialDeps })
+        local springProps, update = React.useState({ initialProps, initialDeps })
         test.update = function(newProps, newDeps)
             update({ newProps, newDeps })
             task.wait(0.1)
@@ -18,10 +19,13 @@ local function createUpdater(initialProps, initialDeps)
         return nil
     end
 
-    test.handle = Roact.mount(e(Test), nil)
+    local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Test)
+    }, ReplicatedStorage))
 
     task.wait()
-    while not test.handle do
+    while not root do
         task.wait()
     end
 

--- a/src/hooks/useSprings.lua
+++ b/src/hooks/useSprings.lua
@@ -3,29 +3,33 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
 local TS = rbxts_include and require(rbxts_include.RuntimeLib)
 
+local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
 local Promise = if TS then TS.Promise else require(script.Parent.Parent.Parent.Promise)
 local Controller = require(script.Parent.Parent.Controller)
 local util = require(script.Parent.Parent.util)
 
+local isRoact17 = not Roact.reconcile
+local useRefKey = if isRoact17 then "current" else "value"
+
 local function useSprings(hooks, length: number, props: { any } | (index: number) -> ({[string]: any}), deps: {any}?)
-    local isImperative = hooks.useValue(nil)
-    local ctrls = hooks.useValue({})
-    local stylesList = hooks.useValue({})
-    local apiList = hooks.useValue({})
+    local isImperative = hooks[if isRoact17 then "useRef" else "useValue"](nil)
+    local ctrls = hooks[if isRoact17 then "useRef" else "useValue"]({})
+    local stylesList = hooks[if isRoact17 then "useRef" else "useValue"]({})
+    local apiList = hooks[if isRoact17 then "useRef" else "useValue"]({})
 
     if typeof(props) == "table" then
-        assert(isImperative.value == nil or isImperative.value == false, "useSprings detected a change from imperative to declarative. This is not supported.")
-        isImperative.value = false
+        assert(isImperative[useRefKey] == nil or isImperative[useRefKey] == false, "useSprings detected a change from imperative to declarative. This is not supported.")
+        isImperative[useRefKey] = false
     elseif typeof(props) == "function" then
-        assert(isImperative.value == nil or isImperative.value == true, "useSprings detected a change from declarative to imperative. This is not supported.")
-        isImperative.value = true
+        assert(isImperative[useRefKey] == nil or isImperative[useRefKey] == true, "useSprings detected a change from declarative to imperative. This is not supported.")
+        isImperative[useRefKey] = true
     else
         error("Expected table or function for useSprings, got " .. typeof(props))
     end
 
     hooks.useEffect(function()
-        if isImperative.value == false then
-            for i, spring in ipairs(ctrls.value) do
+        if isImperative[useRefKey] == false then
+            for i, spring in ipairs(ctrls[useRefKey]) do
                 local startProps = util.merge(props[i], {
                     reset = if props[i].reset then props[i].reset else false,
                 })
@@ -37,31 +41,31 @@ local function useSprings(hooks, length: number, props: { any } | (index: number
     -- Create new controllers when "length" increases, and destroy
     -- the affected controllers when "length" decreases
     hooks.useMemo(function()
-        if length > #ctrls.value then
-            for i = #ctrls.value + 1, length do
+        if length > #ctrls[useRefKey] then
+            for i = #ctrls[useRefKey] + 1, length do
                 local styles, api = Controller.new(if typeof(props) == "table" then props[i] else props(i))
-                ctrls.value[i] = api
-                stylesList.value[i] = styles
+                ctrls[useRefKey][i] = api
+                stylesList[useRefKey][i] = styles
             end
         else
             -- Clean up any unused controllers
-            for i = length + 1, #ctrls.value do
-                ctrls.value[i]:stop()
-                ctrls.value[i] = nil
-                stylesList.value[i] = nil
-                apiList.value[i] = nil
+            for i = length + 1, #ctrls[useRefKey] do
+                ctrls[useRefKey][i]:stop()
+                ctrls[useRefKey][i] = nil
+                stylesList[useRefKey][i] = nil
+                apiList[useRefKey][i] = nil
             end
         end
     end, { length })
 
     hooks.useMemo(function()
-        if isImperative.value then
-            if #ctrls.value > 0 then
-                for apiName, value in pairs(getmetatable(ctrls.value[1])) do
+        if isImperative[useRefKey] then
+            if #ctrls[useRefKey] > 0 then
+                for apiName, value in pairs(getmetatable(ctrls[useRefKey][1])) do
                     if typeof(value) == "function" and apiName ~= "new" then
-                        apiList.value[apiName] = function(apiProps: (index: number) -> any | any)
+                        apiList[useRefKey][apiName] = function(apiProps: (index: number) -> any | any)
                             local promises = {}
-                            for i, spring in ipairs(ctrls.value) do
+                            for i, spring in ipairs(ctrls[useRefKey]) do
                                 table.insert(promises, Promise.new(function(resolve)
                                     local result = spring[apiName](spring, if typeof(apiProps) == "function" then apiProps(i) else apiProps)
 
@@ -86,17 +90,23 @@ local function useSprings(hooks, length: number, props: { any } | (index: number
     -- Cancel the animations of all controllers on unmount
     hooks.useEffect(function()
         return function()
-            for _, ctrl in ipairs(ctrls.value) do
+            for _, ctrl in ipairs(ctrls[useRefKey]) do
                 ctrl:stop()
             end
         end
     end, {})
 
-    if isImperative.value then
-        return stylesList.value, apiList.value
+    if isImperative[useRefKey] then
+        return stylesList[useRefKey], apiList[useRefKey]
     end
 
-    return stylesList.value
+    return stylesList[useRefKey]
+end
+
+if isRoact17 then
+    return function(length: number, props: { any } | (index: number) -> ({[string]: any}), deps: {any}?)
+        return useSprings(Roact, length, props, deps)
+    end
 end
 
 return useSprings

--- a/src/hooks/useSprings.lua
+++ b/src/hooks/useSprings.lua
@@ -3,12 +3,12 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
 local TS = rbxts_include and require(rbxts_include.RuntimeLib)
 
-local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
+local React = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.React)
 local Promise = if TS then TS.Promise else require(script.Parent.Parent.Parent.Promise)
 local Controller = require(script.Parent.Parent.Controller)
 local util = require(script.Parent.Parent.util)
 
-local isRoact17 = not Roact.reconcile
+local isRoact17 = not React.reconcile
 local useRefKey = if isRoact17 then "current" else "value"
 
 local function useSprings(hooks, length: number, props: { any } | (index: number) -> ({[string]: any}), deps: {any}?)
@@ -105,7 +105,7 @@ end
 
 if isRoact17 then
     return function(length: number, props: { any } | (index: number) -> ({[string]: any}), deps: {any}?)
-        return useSprings(Roact, length, props, deps)
+        return useSprings(React, length, props, deps)
     end
 end
 

--- a/src/hooks/useSprings.spec.lua
+++ b/src/hooks/useSprings.spec.lua
@@ -1,15 +1,16 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function createUpdater(initialLength, initialProps, initialDeps)
     local test = {}
 
     local function Test(_)
-        local springProps, update = Roact.useState({ initialLength, initialProps, initialDeps })
+        local springProps, update = React.useState({ initialLength, initialProps, initialDeps })
         test.update = function(newLength, newProps, newDeps)
             update({ newLength, newProps, newDeps })
             task.wait(0.1)
@@ -18,10 +19,13 @@ local function createUpdater(initialLength, initialProps, initialDeps)
         return nil
     end
 
-    test.handle = Roact.mount(e(Test), nil)
+    local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Test)
+    }, ReplicatedStorage))
 
     task.wait()
-    while not test.handle do
+    while not root do
         task.wait()
     end
 

--- a/src/hooks/useSprings.spec.lua
+++ b/src/hooks/useSprings.spec.lua
@@ -1,7 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
@@ -9,20 +8,19 @@ local e = Roact.createElement
 local function createUpdater(initialLength, initialProps, initialDeps)
     local test = {}
 
-    local function Test(_, hooks)
-        local springProps, update = hooks.useState({ initialLength, initialProps, initialDeps })
+    local function Test(_)
+        local springProps, update = Roact.useState({ initialLength, initialProps, initialDeps })
         test.update = function(newLength, newProps, newDeps)
             update({ newLength, newProps, newDeps })
             task.wait(0.1)
         end
-        test.springs, test.api = RoactSpring.useSprings(hooks, springProps[1], springProps[2], springProps[3])
+        test.springs, test.api = RoactSpring.useSprings(springProps[1], springProps[2], springProps[3])
         return nil
     end
 
-    Test = Hooks.new(Roact)(Test)
-
     test.handle = Roact.mount(e(Test), nil)
 
+    task.wait()
     while not test.handle do
         task.wait()
     end

--- a/src/hooks/useTrail.lua
+++ b/src/hooks/useTrail.lua
@@ -3,11 +3,11 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
 local TS = rbxts_include and require(rbxts_include.RuntimeLib)
 
-local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
+local React = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.React)
 local useSprings = require(script.Parent.useSprings)
 local util = require(script.Parent.Parent.util)
 
-local isRoact17 = not Roact.reconcile
+local isRoact17 = not React.reconcile
 local useRefKey = if isRoact17 then "current" else "value"
 
 local function useTrail(hooks, length: number, propsArg, deps: {any}?)
@@ -69,7 +69,7 @@ end
 
 if isRoact17 then
     return function(length: number, propsArg, deps: {any}?)
-        return useTrail(Roact, length, propsArg, deps)
+        return useTrail(React, length, propsArg, deps)
     end
 end
 

--- a/src/hooks/useTrail.lua
+++ b/src/hooks/useTrail.lua
@@ -1,5 +1,14 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local rbxts_include = ReplicatedStorage:FindFirstChild("rbxts_include")
+local TS = rbxts_include and require(rbxts_include.RuntimeLib)
+
+local Roact = if TS then TS.import(script, TS.getModule(script, "@rbxts", "roact").src) else require(script.Parent.Parent.Parent.Roact)
 local useSprings = require(script.Parent.useSprings)
 local util = require(script.Parent.Parent.util)
+
+local isRoact17 = not Roact.reconcile
+local useRefKey = if isRoact17 then "current" else "value"
 
 local function useTrail(hooks, length: number, propsArg, deps: {any}?)
     local isFn = type(propsArg) == "function"
@@ -24,19 +33,24 @@ local function useTrail(hooks, length: number, propsArg, deps: {any}?)
     end, deps or {{}})
 
     -- TODO: Calculate delay for api methods as well
-    local styles, api = useSprings(hooks, length, props, deps)
+    local styles, api
+        if isRoact17 then
+            styles, api = useSprings(length, props, deps)
+        else
+            styles, api = useSprings(hooks, length, props, deps)
+        end
 
-    local modifiedApi = hooks.useValue({})
+    local modifiedApi = hooks[if isRoact17 then "useRef" else "useValue"]({})
 
     -- Return api with modified api.start
     if isFn then
         -- We can't just copy as we want to guarantee the returned api doesn't change its reference
-        table.clear(modifiedApi.value)
+        table.clear(modifiedApi[useRefKey])
         for key, value in pairs(api) do
-            modifiedApi.value[key] = value
+            modifiedApi[useRefKey][key] = value
         end
 
-        modifiedApi.value.start = function(startFn)
+        modifiedApi[useRefKey].start = function(startFn)
             local currentDelay = 0
             return api.start(function(i)
                 local startProps = util.merge({ delay = 0.1 }, startFn(i))
@@ -47,10 +61,16 @@ local function useTrail(hooks, length: number, propsArg, deps: {any}?)
             end)
         end
 
-        return styles, modifiedApi.value
+        return styles, modifiedApi[useRefKey]
     end
 
     return styles
+end
+
+if isRoact17 then
+    return function(length: number, propsArg, deps: {any}?)
+        return useTrail(Roact, length, propsArg, deps)
+    end
 end
 
 return useTrail

--- a/stories/components/CircleButton.lua
+++ b/stories/components/CircleButton.lua
@@ -1,15 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 
 local e = Roact.createElement
 
-local function Button(props, hooks)
+local function Button(props)
 	return e("TextButton", {
-        AnchorPoint = props.AnchorPoint,
-        Position = props.Position,
-		Size = props.Size,
+        AnchorPoint = props.AnchorPoint or Vector2.new(0.5, 0.5),
+        Position = props.Position or UDim2.fromScale(0.5, 0.5),
+		Size = props.Size or UDim2.fromOffset(150, 150),
         BackgroundColor3 = Color3.fromRGB(255, 255, 255),
         AutoButtonColor = false,
         Text = "",
@@ -31,10 +30,4 @@ local function Button(props, hooks)
     })
 end
 
-return Hooks.new(Roact)(Button, {
-    defaultProps = {
-        AnchorPoint = Vector2.new(0.5, 0.5),
-        Position = UDim2.fromScale(0.5, 0.5),
-        Size = UDim2.fromOffset(150, 150),
-    },
-})
+return Button

--- a/stories/components/CircleButton.lua
+++ b/stories/components/CircleButton.lua
@@ -1,8 +1,8 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(props)
 	return e("TextButton", {
@@ -13,9 +13,9 @@ local function Button(props)
         AutoButtonColor = false,
         Text = "",
 
-        [Roact.Event.Activated] = props[Roact.Event.Activated],
-        [Roact.Event.InputBegan] = props[Roact.Event.InputBegan],
-        [Roact.Event.InputEnded] = props[Roact.Event.InputEnded],
+        [React.Event.Activated] = props[React.Event.Activated],
+        [React.Event.InputBegan] = props[React.Event.InputBegan],
+        [React.Event.InputEnded] = props[React.Event.InputEnded],
 	}, {
         UICorner = e("UICorner", {
             CornerRadius = UDim.new(1, 0),

--- a/stories/hooks/useSpringBouncePause.story.lua
+++ b/stories/hooks/useSpringBouncePause.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 local PAUSE_AFTER_SECONDS = 1.5
 
 local function Button(_)
@@ -16,7 +17,7 @@ local function Button(_)
 
 	return e(CircleButton, {
         Position = styles.position,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({
                 to = { position = UDim2.fromScale(0.5, 0.8) },
                 config = { bounce = 1, tension = 180, friction = 0 },
@@ -28,9 +29,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringBouncePause.story.lua
+++ b/stories/hooks/useSpringBouncePause.story.lua
@@ -1,15 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 local PAUSE_AFTER_SECONDS = 1.5
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             position = UDim2.fromScale(0.5, 0.5),
         }
@@ -27,8 +26,6 @@ local function Button(_, hooks)
         end
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringBounceStop.story.lua
+++ b/stories/hooks/useSpringBounceStop.story.lua
@@ -1,15 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 local STOP_AFTER_SECONDS = 3
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             position = UDim2.fromScale(0.5, 0.3),
         }
@@ -27,8 +26,6 @@ local function Button(_, hooks)
         end
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringBounceStop.story.lua
+++ b/stories/hooks/useSpringBounceStop.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 local STOP_AFTER_SECONDS = 3
 
 local function Button(_)
@@ -16,7 +17,7 @@ local function Button(_)
 
 	return e(CircleButton, {
         Position = styles.position,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({
                 to = { position = UDim2.fromScale(0.5, 0.8) },
                 config = { mass = 2.5, bounce = 1, tension = 180, friction = 0 },
@@ -28,9 +29,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringColorDeclarative.story.lua
+++ b/stories/hooks/useSpringColorDeclarative.story.lua
@@ -1,12 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
-    local toggle, setToggle = Roact.useState(false)
+    local toggle, setToggle = React.useState(false)
     local styles = RoactSpring.useSpring({
         color = if toggle then Color3.fromRGB(0, 0, 0) else Color3.fromRGB(255, 255, 255),
     })
@@ -19,7 +20,7 @@ local function Button(_)
         AutoButtonColor = false,
         Text = "",
 
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             setToggle(function(prevState)
                 return not prevState
             end)
@@ -30,9 +31,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringColorDeclarative.story.lua
+++ b/stories/hooks/useSpringColorDeclarative.story.lua
@@ -1,14 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local toggle, setToggle = hooks.useState(false)
-    local styles = RoactSpring.useSpring(hooks, {
+local function Button(_)
+    local toggle, setToggle = Roact.useState(false)
+    local styles = RoactSpring.useSpring({
         color = if toggle then Color3.fromRGB(0, 0, 0) else Color3.fromRGB(255, 255, 255),
     })
 
@@ -29,8 +28,6 @@ local function Button(_, hooks)
         UICorner = e("UICorner"),
     })
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringDeclarative.story.lua
+++ b/stories/hooks/useSpringDeclarative.story.lua
@@ -1,15 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local toggle, setToggle = hooks.useState(false)
-    local styles = RoactSpring.useSpring(hooks, {
+local function Button(_)
+    local toggle, setToggle = Roact.useState(false)
+    local styles = RoactSpring.useSpring({
         position = if toggle then UDim2.fromScale(0.7, 0.5) else UDim2.fromScale(0.3, 0.5),
         config = if toggle then { tension = 200 } else { tension = 50 },
     }, { toggle })
@@ -23,8 +22,6 @@ local function Button(_, hooks)
         end,
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringDeclarative.story.lua
+++ b/stories/hooks/useSpringDeclarative.story.lua
@@ -1,13 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
-    local toggle, setToggle = Roact.useState(false)
+    local toggle, setToggle = React.useState(false)
     local styles = RoactSpring.useSpring({
         position = if toggle then UDim2.fromScale(0.7, 0.5) else UDim2.fromScale(0.3, 0.5),
         config = if toggle then { tension = 200 } else { tension = 50 },
@@ -15,7 +16,7 @@ local function Button(_)
 
 	return e(CircleButton, {
         Position = styles.position,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             setToggle(function(prevState)
                 return not prevState
             end)
@@ -24,9 +25,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringDrag.story.lua
+++ b/stories/hooks/useSpringDrag.story.lua
@@ -8,11 +8,12 @@ local RunService = game:GetService("RunService")
 local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles, api = RoactSpring.useSpring(function()
@@ -22,13 +23,13 @@ local function Button(_)
             config = { tension = 100, friction = 10 },
         }
     end)
-    local connection = Roact.useRef()
+    local connection = React.useRef()
 
 	return e(CircleButton, {
         Position = styles.position,
 		Size = styles.size,
 
-        [Roact.Event.InputBegan] = function(_, input)
+        [React.Event.InputBegan] = function(_, input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 if not connection.value then
                     connection.value = RunService.Heartbeat:Connect(function()
@@ -42,7 +43,7 @@ local function Button(_)
                 end
             end
         end,
-        [Roact.Event.InputEnded] = function(_,input)
+        [React.Event.InputEnded] = function(_,input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 if connection.value then
                     api.start({ size = UDim2.fromOffset(150, 150) })
@@ -55,9 +56,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringDrag.story.lua
+++ b/stories/hooks/useSpringDrag.story.lua
@@ -9,21 +9,20 @@ local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             size = UDim2.fromOffset(150, 150),
             position = UDim2.fromScale(0.5, 0.5),
             config = { tension = 100, friction = 10 },
         }
     end)
-    local connection = hooks.useValue()
+    local connection = Roact.useRef()
 
 	return e(CircleButton, {
         Position = styles.position,
@@ -54,8 +53,6 @@ local function Button(_, hooks)
         end
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringEasingClick.story.lua
+++ b/stories/hooks/useSpringEasingClick.story.lua
@@ -8,20 +8,19 @@ local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             position = UDim2.fromScale(0.5, 0.5),
         }
     end)
 
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
@@ -41,8 +40,6 @@ local function Button(_, hooks)
         Position = styles.position,
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringEasingClick.story.lua
+++ b/stories/hooks/useSpringEasingClick.story.lua
@@ -7,11 +7,12 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles, api = RoactSpring.useSpring(function()
@@ -20,7 +21,7 @@ local function Button(_)
         }
     end)
 
-    Roact.useEffect(function()
+    React.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
@@ -42,9 +43,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringFromDeclarative.story.lua
+++ b/stories/hooks/useSpringFromDeclarative.story.lua
@@ -1,15 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local toggle, setToggle = hooks.useState(false)
-    local styles = RoactSpring.useSpring(hooks, {
+local function Button(_)
+    local toggle, setToggle = Roact.useState(false)
+    local styles = RoactSpring.useSpring({
         from = { position = if toggle then UDim2.fromScale(0.3, 0.2) else UDim2.fromScale(0.7, 0.2) },
         to = { position = if toggle then UDim2.fromScale(0.7, 0.5) else UDim2.fromScale(0.3, 0.5) },
     }, { toggle })
@@ -23,8 +22,6 @@ local function Button(_, hooks)
         end,
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringFromDeclarative.story.lua
+++ b/stories/hooks/useSpringFromDeclarative.story.lua
@@ -1,13 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
-    local toggle, setToggle = Roact.useState(false)
+    local toggle, setToggle = React.useState(false)
     local styles = RoactSpring.useSpring({
         from = { position = if toggle then UDim2.fromScale(0.3, 0.2) else UDim2.fromScale(0.7, 0.2) },
         to = { position = if toggle then UDim2.fromScale(0.7, 0.5) else UDim2.fromScale(0.3, 0.5) },
@@ -15,7 +16,7 @@ local function Button(_)
 
 	return e(CircleButton, {
         Position = styles.position,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             setToggle(function(prevState)
                 return not prevState
             end)
@@ -24,9 +25,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringFromImperative.story.lua
+++ b/stories/hooks/useSpringFromImperative.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles, api = RoactSpring.useSpring(function()
@@ -13,7 +14,7 @@ local function Button(_)
 
 	return e(CircleButton, {
         Position = styles.position,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({
                 from = { position = UDim2.fromScale(0.2, 0.2) },
                 to = { position = UDim2.fromScale(0.5, 0.8) },
@@ -23,9 +24,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringFromImperative.story.lua
+++ b/stories/hooks/useSpringFromImperative.story.lua
@@ -1,14 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return { position = UDim2.fromScale(0.5, 0.5) }
     end)
 
@@ -22,8 +21,6 @@ local function Button(_, hooks)
         end,
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringImmediate.story.lua
+++ b/stories/hooks/useSpringImmediate.story.lua
@@ -1,14 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return { position = UDim2.fromScale(0.5, 0.5), }
     end)
 
@@ -22,8 +21,6 @@ local function Button(_, hooks)
         end,
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringImmediate.story.lua
+++ b/stories/hooks/useSpringImmediate.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles, api = RoactSpring.useSpring(function()
@@ -13,7 +14,7 @@ local function Button(_)
 
 	return e(CircleButton, {
         Position = styles.position,
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({
                 position = UDim2.fromScale(0.5, 0.8),
                 immediate = true,
@@ -23,9 +24,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringImperative.story.lua
+++ b/stories/hooks/useSpringImperative.story.lua
@@ -1,14 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return { position = UDim2.fromScale(0.5, 0.5) }
     end)
 
@@ -22,8 +21,6 @@ local function Button(_, hooks)
         end,
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringImperative.story.lua
+++ b/stories/hooks/useSpringImperative.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles, api = RoactSpring.useSpring(function()
@@ -14,7 +15,7 @@ local function Button(_)
 	return e(CircleButton, {
         Position = styles.position,
 
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({
                 position = UDim2.fromScale(0.5, 0.8),
             })
@@ -23,9 +24,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringLoop.story.lua
+++ b/stories/hooks/useSpringLoop.story.lua
@@ -1,9 +1,10 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles = RoactSpring.useSpring({
@@ -24,9 +25,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringLoop.story.lua
+++ b/stories/hooks/useSpringLoop.story.lua
@@ -1,13 +1,12 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles = RoactSpring.useSpring(hooks, {
+local function Button(_)
+    local styles = RoactSpring.useSpring({
         from = { transparency = 0 },
         to = { transparency = 1 },
         loop = true,
@@ -23,8 +22,6 @@ local function Button(_, hooks)
         UICorner = e("UICorner"),
     })
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringVelocity.story.lua
+++ b/stories/hooks/useSpringVelocity.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local function Button(_)
     local styles, api = RoactSpring.useSpring(function()
@@ -20,16 +21,19 @@ local function Button(_)
 	return e(CircleButton, {
         Position = styles.position,
 
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             api.start({ position = UDim2.fromScale(0.5, 0.6) })
         end
 	})
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringVelocity.story.lua
+++ b/stories/hooks/useSpringVelocity.story.lua
@@ -1,14 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
 local e = Roact.createElement
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useSpring(hooks, function()
+local function Button(_)
+    local styles, api = RoactSpring.useSpring(function()
         return {
             position = UDim2.fromScale(0.5, 0.6),
             config = {
@@ -26,8 +25,6 @@ local function Button(_, hooks)
         end
 	})
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringsEasing.story.lua
+++ b/stories/hooks/useSpringsEasing.story.lua
@@ -2,7 +2,6 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
@@ -15,8 +14,8 @@ for name, easing in pairs(RoactSpring.easings) do
     })
 end
 
-local function Button(_, hooks)
-    local toggle, setToggle = hooks.useState(false)
+local function Button(_)
+    local toggle, setToggle = Roact.useState(false)
 
     local springProps = {}
     for i in ipairs(easingsArray) do
@@ -25,9 +24,9 @@ local function Button(_, hooks)
             config = { easing = easingsArray[i].easing, duration = 2 },
         })
     end
-    local springs = RoactSpring.useSprings(hooks, #easingsArray, springProps)
+    local springs = RoactSpring.useSprings(#easingsArray, springProps)
 
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 setToggle(function(prevState)
@@ -69,8 +68,6 @@ local function Button(_, hooks)
 
 	return Roact.createFragment(buttons)
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useSpringsEasing.story.lua
+++ b/stories/hooks/useSpringsEasing.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local easingsArray = {}
 for name, easing in pairs(RoactSpring.easings) do
@@ -15,7 +16,7 @@ for name, easing in pairs(RoactSpring.easings) do
 end
 
 local function Button(_)
-    local toggle, setToggle = Roact.useState(false)
+    local toggle, setToggle = React.useState(false)
 
     local springProps = {}
     for i in ipairs(easingsArray) do
@@ -26,7 +27,7 @@ local function Button(_)
     end
     local springs = RoactSpring.useSprings(#easingsArray, springProps)
 
-    Roact.useEffect(function()
+    React.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 setToggle(function(prevState)
@@ -43,7 +44,7 @@ local function Button(_)
     local buttons = {}
 
     for index, easing in ipairs(easingsArray) do
-        buttons[easing.name] = Roact.createFragment({
+        buttons[easing.name] = React.createFragment({
             Button = e("TextButton", {
                 AnchorPoint = Vector2.new(0.5, 0.5),
                 Position = springs[index].position,
@@ -66,13 +67,16 @@ local function Button(_)
         })
     end
 
-	return Roact.createFragment(buttons)
+	return React.createFragment(buttons)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringsList.story.lua
+++ b/stories/hooks/useSpringsList.story.lua
@@ -8,10 +8,11 @@ local RunService = game:GetService("RunService")
 local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local buttonProps = {
     {
@@ -49,7 +50,7 @@ local function Button(_)
             ZIndex = 1,
         }
     end)
-    local connection = Roact.useRef()
+    local connection = React.useRef()
 
     local buttons = {}
 
@@ -62,7 +63,7 @@ local function Button(_)
             AutoButtonColor = false,
             ZIndex = springs[index].ZIndex,
 
-            [Roact.Event.InputBegan] = function(button, input)
+            [React.Event.InputBegan] = function(button, input)
                 if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                     connection.value = RunService.Heartbeat:Connect(function()
                         local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
@@ -114,7 +115,7 @@ local function Button(_)
                     end)
                 end
             end,
-            [Roact.Event.InputEnded] = function(button,input)
+            [React.Event.InputEnded] = function(button,input)
                 if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                     if connection.value then
                         connection.value:Disconnect()
@@ -182,9 +183,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useSpringsList.story.lua
+++ b/stories/hooks/useSpringsList.story.lua
@@ -9,7 +9,6 @@ local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
@@ -42,15 +41,15 @@ local buttonProps = {
     }
 }
 
-local function Button(_, hooks)
-    local springs, api = RoactSpring.useSprings(hooks, #buttonProps, function(i)
+local function Button(_)
+    local springs, api = RoactSpring.useSprings(#buttonProps, function(i)
         return {
             Position = UDim2.fromScale(0.5, i * 0.16),
             Size = UDim2.fromScale(1, 0.13), 
             ZIndex = 1,
         }
     end)
-    local connection = hooks.useValue()
+    local connection = Roact.useRef()
 
     local buttons = {}
 
@@ -181,8 +180,6 @@ local function Button(_, hooks)
 		BackgroundTransparency = 1,
 	}, buttons)
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useTrailFollow.story.lua
+++ b/stories/hooks/useTrailFollow.story.lua
@@ -8,7 +8,6 @@ local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
@@ -20,8 +19,8 @@ local buttonColors = {
     Color3.fromRGB(232, 221, 255),
 }
 
-local function Button(_, hooks)
-    local styles, api = RoactSpring.useTrail(hooks, #buttonColors, function(i)
+local function Button(_)
+    local styles, api = RoactSpring.useTrail(#buttonColors, function(i)
         return {
             position = UDim2.fromScale(0.5, 0.5),
             config = { damping = 1, frequency = 0.3 + i * 0.03 },
@@ -29,7 +28,7 @@ local function Button(_, hooks)
         }
     end)
     
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         local conn = UserInputService.InputChanged:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseMovement or input.UserInputType == Enum.UserInputType.Touch then
                 local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
@@ -62,8 +61,6 @@ local function Button(_, hooks)
 
 	return Roact.createFragment(contents)
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useTrailFollow.story.lua
+++ b/stories/hooks/useTrailFollow.story.lua
@@ -7,10 +7,11 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local buttonColors = {
     Color3.fromRGB(167, 229, 255),
@@ -28,7 +29,7 @@ local function Button(_)
         }
     end)
     
-    Roact.useEffect(function()
+    React.useEffect(function()
         local conn = UserInputService.InputChanged:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseMovement or input.UserInputType == Enum.UserInputType.Touch then
                 local mousePos = UserInputService:GetMouseLocation() - Vector2.new(0, GuiService:GetGuiInset().Y)
@@ -59,13 +60,16 @@ local function Button(_)
         })
     end
 
-	return Roact.createFragment(contents)
+	return React.createFragment(contents)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useTrailList.story.lua
+++ b/stories/hooks/useTrailList.story.lua
@@ -2,7 +2,6 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
@@ -35,8 +34,8 @@ local buttonProps = {
     }
 }
 
-local function Button(_, hooks)
-    local toggle, setToggle = hooks.useState(false)
+local function Button(_)
+    local toggle, setToggle = Roact.useState(false)
 
     local springProps = {}
     for i in ipairs(buttonProps) do
@@ -46,9 +45,9 @@ local function Button(_, hooks)
             config = { damping = 1, frequency = 0.3 },
         })
     end
-    local springs = RoactSpring.useTrail(hooks, #buttonProps, springProps)
+    local springs = RoactSpring.useTrail(#buttonProps, springProps)
 
-    hooks.useEffect(function()
+    Roact.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 setToggle(function(prevState)
@@ -113,8 +112,6 @@ local function Button(_, hooks)
 		BackgroundTransparency = 1,
 	}, buttons)
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/hooks/useTrailList.story.lua
+++ b/stories/hooks/useTrailList.story.lua
@@ -1,10 +1,11 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local buttonProps = {
     {
@@ -35,7 +36,7 @@ local buttonProps = {
 }
 
 local function Button(_)
-    local toggle, setToggle = Roact.useState(false)
+    local toggle, setToggle = React.useState(false)
 
     local springProps = {}
     for i in ipairs(buttonProps) do
@@ -47,7 +48,7 @@ local function Button(_)
     end
     local springs = RoactSpring.useTrail(#buttonProps, springProps)
 
-    Roact.useEffect(function()
+    React.useEffect(function()
         local conn = UserInputService.InputEnded:Connect(function(input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 setToggle(function(prevState)
@@ -114,9 +115,12 @@ local function Button(_)
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useTrailText.story.lua
+++ b/stories/hooks/useTrailText.story.lua
@@ -1,14 +1,15 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
-local e = Roact.createElement
+local e = React.createElement
 
 local textList = { "Lorem", "Ipsum", "Dolor", "Sit" }
 
 local function Button(_)
-    local toggle, setToggle = Roact.useState(true)
+    local toggle, setToggle = React.useState(true)
 
     local springProps = {}
     for _ in ipairs(textList) do
@@ -58,7 +59,7 @@ local function Button(_)
         AutoButtonColor = false,
         Text = "",
 
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             setToggle(function(prevState)
                 return not prevState
             end)
@@ -73,15 +74,18 @@ local function Button(_)
             UIListLayout = e("UIListLayout", {
                 SortOrder = Enum.SortOrder.LayoutOrder,
             }),
-            Text = Roact.createFragment(contents),
+            Text = React.createFragment(contents),
         })
     })
 end
 
 return function(target)
-	local handle = Roact.mount(e(Button), target, "Button")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Button)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/hooks/useTrailText.story.lua
+++ b/stories/hooks/useTrailText.story.lua
@@ -1,15 +1,14 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Roact = require(ReplicatedStorage.Packages.Roact)
-local Hooks = require(ReplicatedStorage.Packages.Hooks)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 
 local e = Roact.createElement
 
 local textList = { "Lorem", "Ipsum", "Dolor", "Sit" }
 
-local function Button(_, hooks)
-    local toggle, setToggle = hooks.useState(true)
+local function Button(_)
+    local toggle, setToggle = Roact.useState(true)
 
     local springProps = {}
     for _ in ipairs(textList) do
@@ -20,7 +19,7 @@ local function Button(_, hooks)
             config = { damping = 1, frequency = 0.3 },
         })
     end
-    local springs = RoactSpring.useTrail(hooks, #textList, springProps)
+    local springs = RoactSpring.useTrail(#textList, springProps)
 
     local contents = {}
 
@@ -78,8 +77,6 @@ local function Button(_, hooks)
         })
     })
 end
-
-Button = Hooks.new(Roact)(Button)
 
 return function(target)
 	local handle = Roact.mount(e(Button), target, "Button")

--- a/stories/others/Spring.story.lua
+++ b/stories/others/Spring.story.lua
@@ -1,12 +1,13 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
-local Example = Roact.Component:extend("Example")
+local Example = React.Component:extend("Example")
 
 function Example:init()
     self.styles, self.api = RoactSpring.Controller.new({
@@ -18,7 +19,7 @@ function Example:render()
     return e(CircleButton, {
         Position = self.styles.position,
 
-        [Roact.Event.Activated] = function()
+        [React.Event.Activated] = function()
             self.api:start({
                 position = UDim2.fromScale(0.5, 0.8),
             })
@@ -27,9 +28,12 @@ function Example:render()
 end
 
 return function(target)
-	local handle = Roact.mount(e(Example), target, "Example")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Example)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/stories/others/SpringDrag.story.lua
+++ b/stories/others/SpringDrag.story.lua
@@ -8,13 +8,14 @@ local RunService = game:GetService("RunService")
 local UserInputService = game:GetService("UserInputService")
 local GuiService = game:GetService("GuiService")
 
-local Roact = require(ReplicatedStorage.Packages.Roact)
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
 local RoactSpring = require(ReplicatedStorage.Packages.RoactSpring)
 local CircleButton = require(script.Parent.Parent.components.CircleButton)
 
-local e = Roact.createElement
+local e = React.createElement
 
-local Example = Roact.Component:extend("Example")
+local Example = React.Component:extend("Example")
 
 function Example:init()
     self.styles, self.api = RoactSpring.Controller.new({
@@ -28,7 +29,7 @@ function Example:render()
         Position = self.styles.position,
 		Size = self.styles.size,
 
-        [Roact.Event.InputBegan] = function(button, input)
+        [React.Event.InputBegan] = function(button, input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 if not self.connection then
                     self.connection = RunService.Heartbeat:Connect(function()
@@ -43,7 +44,7 @@ function Example:render()
                 end
             end
         end,
-        [Roact.Event.InputEnded] = function(_,input)
+        [React.Event.InputEnded] = function(_,input)
             if input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
                 if self.connection then
                     self.api:start({
@@ -59,9 +60,12 @@ function Example:render()
 end
 
 return function(target)
-	local handle = Roact.mount(e(Example), target, "Example")
+	local root = ReactRoblox.createRoot(Instance.new("Folder"))
+    root:render(ReactRoblox.createPortal({
+        App = e(Example)
+    }, target))
 
 	return function()
-		Roact.unmount(handle)
+		root:unmount()
 	end
 end

--- a/wally.toml
+++ b/wally.toml
@@ -8,7 +8,6 @@ registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 
 [dependencies]
-Roact = "roblox/roact@^1"
+Roact = "core-packages/roact-compat@17.0.1-rc.16.1"
 Promise = "evaera/promise@^4.0"
-Hooks = "kampfkarren/roact-hooks@^0.4"
 TestEZ = "roblox/testez@^0.4"

--- a/wally.toml
+++ b/wally.toml
@@ -8,6 +8,5 @@ registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 
 [dependencies]
-Roact = "core-packages/roact-compat@17.0.1-rc.16.1"
 Promise = "evaera/promise@^4.0"
 TestEZ = "roblox/testez@^0.4"


### PR DESCRIPTION
Add support for [Roact17](https://github.com/grilme99/CorePackages). The usage is almost identical - now you can use roact-spring's hooks without passing in a hook object.

```lua
local styles = RoactSpring.useSpring({
    color = if toggle then Color3.fromRGB(0, 0, 0) else Color3.fromRGB(255, 255, 255),
})
```

[roact-hooks](https://github.com/Kampfkarren/roact-hooks) is still supported.
```lua
local styles = RoactSpring.useSpring(hooks, {
    color = if toggle then Color3.fromRGB(0, 0, 0) else Color3.fromRGB(255, 255, 255),
})
```