### PR TITLE
Reset velocity on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fixed `reset` prop not properly resetting velocity, previously yielding really fast springs in certain cases ([@chriscerie](https://github.com/chriscerie) in [#36](https://github.com/chriscerie/roact-spring/pull/36))
 
 ## 1.1.1 (Nov 5, 2022)
 * Fixed `error` when passing reset = true without using from prop ([@chriscerie](https://github.com/chriscerie) in [#20](https://github.com/chriscerie/roact-spring/pull/28))

--- a/src/SpringValue.lua
+++ b/src/SpringValue.lua
@@ -94,6 +94,10 @@ function SpringValue:_update(props)
         if reset then
             anim.values = table.clone(anim.fromValues)
             anim.lastPosition = if from then helpers.getValuesFromType(from) else anim.lastPosition
+
+            local length = #anim.v0
+            anim.v0 = table.create(length, nil)
+            anim.lastVelocity = table.create(length, nil)
         end
 
         anim.toValues = helpers.getValuesFromType(to)


### PR DESCRIPTION
Fixes `reset` prop not resetting velocity, previously yielding really fast springs in certain cases. Reported by @nickthebob