### PR TITLE
Export type common.ReactBinding for strict typing

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -6,6 +6,7 @@ local useSprings = require(script.hooks.useSprings)
 
 export type AnimatableType = common.AnimatableType
 export type AnimationStyle = common.AnimationStyle
+export type ReactBinding = common.ReactBinding
 
 export type UseSpringsApi<T> = useSprings.UseSpringsApi<T>
 export type UseSpringsStylesList = useSprings.UseSpringsStylesList


### PR DESCRIPTION
When using strict typing, passing `ReactSpring.ReactBinding` is not exported by the main module in wally, so this exposes that type for ease of use. Especially useful when working with [JohnnyMorganz/wally-package-types](https://github.com/JohnnyMorganz/wally-package-types).